### PR TITLE
fix: codigo de 200 a 201 al realizar el login

### DIFF
--- a/src/main/java/com/sacristan/api/global/security/utils/controller/SecurityController.java
+++ b/src/main/java/com/sacristan/api/global/security/utils/controller/SecurityController.java
@@ -82,7 +82,7 @@ public class SecurityController
                 token,
                 refreshToken
         );
-        return ResponseEntity.ok(jwtUserResponse);
+        return ResponseEntity.status(HttpStatus.CREATED).body(jwtUserResponse);
     }
 
     @PostMapping("/logout")


### PR DESCRIPTION
This pull request updates the HTTP status code returned by the `login` endpoint in `SecurityController`. Instead of returning a standard `200 OK`, the endpoint now responds with a `201 Created` status when a user successfully logs in. This change makes the response more explicit about the creation of a new authentication token.

* Changed the return value in `SecurityController.login` to use `HttpStatus.CREATED` (`201`) instead of `HttpStatus.OK` (`200`) for successful login responses. (`[src/main/java/com/sacristan/api/global/security/utils/controller/SecurityController.javaL85-R85](diffhunk://#diff-cbc68b674097363ce7e87e4ec2d779419805117d6dc777bacb29429f2c61b424L85-R85)`)