### PR TITLE
feat: validación hora fin e inicio de una sequence-routine

### DIFF
--- a/src/main/java/com/sacristan/api/interfaces/admin/services/model/routine/RoutineCrudService.java
+++ b/src/main/java/com/sacristan/api/interfaces/admin/services/model/routine/RoutineCrudService.java
@@ -49,6 +49,13 @@ public class RoutineCrudService {
                             .orElseThrow(() -> new NoSuchElementException("Sequence not found with id: " + routineSequence.getSequence().getId()));
                     routineSequence.setSequence(sequence);
                 }
+
+                if(routineSequence.getStartTime() == null || routineSequence.getEndTime() == null) {
+                    throw new IllegalArgumentException("Start time and end time must be provided for each routine sequence.");
+                }else if(routineSequence.getStartTime().isAfter(routineSequence.getEndTime())) {
+                    throw new IllegalArgumentException("Start time must be before end time for each routine sequence.");
+                }
+
                 routineSequence.setRoutine(routine);
             });
         }
@@ -80,6 +87,12 @@ public class RoutineCrudService {
             for (RoutineSequence incomingRs : newRoutine.getSequences()) {
 
                 if (incomingRs.getSequence() != null && incomingRs.getSequence().getId() != null) {
+
+                    if(incomingRs.getStartTime() == null || incomingRs.getEndTime() == null) {
+                        throw new IllegalArgumentException("Start time and end time must be provided for each routine sequence.");
+                    }else if(incomingRs.getStartTime().isAfter(incomingRs.getEndTime())) {
+                        throw new IllegalArgumentException("Start time must be before end time for each routine sequence.");
+                    }
 
                     if (incomingRs.getId() != null) {
                         managedRoutine.getSequences().stream()


### PR DESCRIPTION
This pull request adds validation logic to ensure that routine sequences have valid start and end times when creating or updating a routine. The most important changes are grouped by the affected operations:

Validation improvements for routine sequences:

* Added checks in the `create` method of `RoutineCrudService` to ensure that each routine sequence has both `startTime` and `endTime` set, and that `startTime` is before `endTime`. If these conditions are not met, an `IllegalArgumentException` is thrown.
* Added similar validation checks in the `update` method of `RoutineCrudService` for incoming routine sequences, enforcing the same requirements for `startTime` and `endTime`.